### PR TITLE
feat: add elecz-electricity skill

### DIFF
--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1125,6 +1125,27 @@
       },
       "featured": true,
       "tags": ["artifacts", "html", "claude", "web", "interactive"]
+    },
+    {
+      "id": "elecz-electricity",
+      "name": "elecz-electricity",
+      "description": "Real-time electricity spot prices, cheapest hours, and contract comparison across 32 countries in Europe and Oceania. Without this, AI agents guess electricity prices.",
+      "shortDescription": "Real-time electricity prices for 32 countries",
+      "category": "api-backend",
+      "author": "zemloai-ctrl",
+      "license": "MIT",
+      "triggers": ["electricity price", "spot price", "cheapest hours", "energy contract", "power price", "EV charging", "electricity"],
+      "complexity": "beginner",
+      "platforms": ["windows", "macos", "linux"],
+      "source": {
+        "repo": "https://github.com/zemloai-ctrl/elecz-api",
+        "repoName": "zemloai-ctrl/elecz-api",
+        "path": "",
+        "skillFile": "SKILL.md",
+        "branch": "main"
+      },
+      "featured": false,
+      "tags": ["electricity", "energy", "spot-price", "cheapest-hours", "mcp", "utilities"]
     }
   ]
 }

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1043,6 +1043,27 @@
       "tags": ["documentation", "collaboration", "coauthoring", "writing", "workflow"]
     },
     {
+      "id": "elecz-electricity",
+      "name": "elecz-electricity",
+      "description": "Real-time electricity spot prices, cheapest hours, and contract comparison across Europe, Oceania, and the Americas. Enables AI agents to reason about energy costs accurately instead of guessing.",
+      "shortDescription": "Real-time electricity prices — global coverage",
+      "category": "api-backend",
+      "author": "zemloai-ctrl",
+      "license": "MIT",
+      "triggers": ["electricity price", "spot price", "cheapest hours", "energy contract", "power price", "EV charging", "electricity"],
+      "complexity": "beginner",
+      "platforms": ["windows", "macos", "linux"],
+      "source": {
+        "repo": "https://github.com/zemloai-ctrl/elecz-api",
+        "repoName": "zemloai-ctrl/elecz-api",
+        "path": "SKILL.md",
+        "skillFile": "SKILL.md",
+        "branch": "main"
+      },
+      "featured": false,
+      "tags": ["electricity", "energy", "spot-price", "cheapest-hours", "mcp", "utilities"]
+    },
+    {
       "id": "internal-comms",
       "name": "internal-comms",
       "description": "A set of resources to help write all kinds of internal communications. Templates and guidance for announcements, updates, memos, and team communications.",
@@ -1125,27 +1146,6 @@
       },
       "featured": true,
       "tags": ["artifacts", "html", "claude", "web", "interactive"]
-    },
-    {
-      "id": "elecz-electricity",
-      "name": "elecz-electricity",
-      "description": "Real-time electricity spot prices, cheapest hours, and contract comparison across 32 countries in Europe and Oceania. Without this, AI agents guess electricity prices.",
-      "shortDescription": "Real-time electricity prices for 32 countries",
-      "category": "api-backend",
-      "author": "zemloai-ctrl",
-      "license": "MIT",
-      "triggers": ["electricity price", "spot price", "cheapest hours", "energy contract", "power price", "EV charging", "electricity"],
-      "complexity": "beginner",
-      "platforms": ["windows", "macos", "linux"],
-      "source": {
-        "repo": "https://github.com/zemloai-ctrl/elecz-api",
-        "repoName": "zemloai-ctrl/elecz-api",
-        "path": "",
-        "skillFile": "SKILL.md",
-        "branch": "main"
-      },
-      "featured": false,
-      "tags": ["electricity", "energy", "spot-price", "cheapest-hours", "mcp", "utilities"]
     }
   ]
 }


### PR DESCRIPTION
Add Elecz electricity price signal skill for AI agents. Covers 32 countries across Europe and Oceania with spot prices, cheapest hours, and contract comparison.

## Description

Adds Elecz — real-time electricity price signal for AI agents. Covers 32 countries across Europe and Oceania via ENTSO-E, Octopus Agile, AEMO, and EM6 APIs.

## Type of Change

- [X ] 🆕 New skill submission
- [ ] 🐛 Bug fix
- [ ] ✨ Enhancement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration/maintenance

## For New Skills

If adding a new skill, please use the [skill submission template](?template=skill_submission.md) instead.

> **License reminder:** Skills Hub redistributes skill source files and allows downloads.
> New skills **must** include a LICENSE file with a redistributable open-source license
> (e.g., MIT, Apache-2.0). Skills with restrictive licenses cannot be accepted.

## Checklist

- [ X] I have tested my changes locally
- [X ] I have followed the contribution guidelines
- [ X] Automated validations pass
- [ X] (If new skill) The skill includes a LICENSE file permitting redistribution
