### PR TITLE
Add Skills宝 to install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Or explore the [skills registry](./skills/registry.json) directly.
 
 **Skills are auto-discovered!** Just add them to `.github/skills/` and Copilot loads them automatically based on their `name` and `description` frontmatter.
 
+For Chinese users, [Skills宝](https://skilery.com) is another place to discover and install skills.
+
 ### Option 1: CLI Extension (Recommended)
 
 ```bash


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language skills discovery option. The repo already provides a curated Copilot skills hub, so this keeps the installation section aligned with broader skill discovery resources.