### PR TITLE
feat: add mailtrap-email-integration skill

### DIFF
--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1133,7 +1133,7 @@
       "shortDescription": "Transactional email via Mailtrap API with sandbox testing and domain setup",
       "category": "api-backend",
       "author": "mailtrap",
-      "license": "Not specified",
+      "license": "MIT",
       "triggers": ["email", "mailtrap", "transactional email", "smtp", "email api", "sandbox testing", "domain verification", "spf", "dkim"],
       "complexity": "intermediate",
       "source": {

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1125,6 +1125,21 @@
       },
       "featured": true,
       "tags": ["artifacts", "html", "claude", "web", "interactive"]
+    },
+    {
+      "id": "mailtrap-email-integration",
+      "name": "Mailtrap Email Integration",
+      "description": "Patterns for integrating transactional email sending using Mailtrap's Email API and Sandbox. Covers sandbox vs production separation, API authentication, sending domain verification (SPF/DKIM/DMARC), and contacts management. Use when implementing email-sending features or debugging delivery issues.",
+      "shortDescription": "Transactional email via Mailtrap API with sandbox testing and domain setup",
+      "category": "api-backend",
+      "author": "mailtrap",
+      "license": "Not specified",
+      "triggers": ["email", "mailtrap", "transactional email", "smtp", "email api", "sandbox testing", "domain verification", "spf", "dkim"],
+      "complexity": "intermediate",
+      "source": {
+        "repo": "https://github.com/mailtrap/mailtrap-skills",
+        "path": "skills/sending-emails/SKILL.md"
     }
+}
   ]
 }

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1139,7 +1139,7 @@
       "source": {
         "repo": "https://github.com/mailtrap/mailtrap-skills",
         "path": "skills/sending-emails/SKILL.md"
+      }
     }
-}
   ]
 }


### PR DESCRIPTION
Adds Mailtrap email integration skill to the api-backend category covering transactional email sending, sandbox testing, domain verification, and contacts management.

## Description

<!-- Briefly describe your changes -->

## Type of Change

- [ ] 🆕 New skill submission
- [ ] 🐛 Bug fix
- [ ] ✨ Enhancement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration/maintenance

## For New Skills

If adding a new skill, please use the [skill submission template](?template=skill_submission.md) instead.

> **License reminder:** Skills Hub redistributes skill source files and allows downloads.
> New skills **must** include a LICENSE file with a redistributable open-source license
> (e.g., MIT, Apache-2.0). Skills with restrictive licenses cannot be accepted.

## Checklist

- [ ] I have tested my changes locally
- [ ] I have followed the contribution guidelines
- [ ] Automated validations pass
- [ ] (If new skill) The skill includes a LICENSE file permitting redistribution
