### PR TITLE
Add UIZZE anti UI slop skill

### DIFF
--- a/skills/registry.json
+++ b/skills/registry.json
@@ -168,8 +168,8 @@
         "linux"
       ],
       "source": {
-        "repo": "https://github.com/samuelbushi/uizze",
-        "repoName": "samuelbushi/uizze",
+        "repo": "https://github.com/uizze/uizze",
+        "repoName": "uizze/uizze",
         "path": "skills/anti-ui-slop/SKILL.md",
         "branch": "main"
       },

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -147,6 +147,42 @@
       ]
     },
     {
+      "id": "anti-ui-slop",
+      "name": "STOP UI SLOP",
+      "description": "Stop generic UI before it ships. Turn real interface evidence into a product-specific design contract, implement the states the flow actually needs, and enforce a hard finish gate for React, Next.js, web, and iOS interfaces.",
+      "shortDescription": "Stop generic UI with evidence, states, and a hard finish gate",
+      "category": "frontend-ui",
+      "author": "UIZZE",
+      "license": "MIT",
+      "triggers": [
+        "stop UI slop",
+        "review this UI",
+        "make this interface product-specific",
+        "finish gate",
+        "generic dashboard"
+      ],
+      "complexity": "advanced",
+      "platforms": [
+        "windows",
+        "macos",
+        "linux"
+      ],
+      "source": {
+        "repo": "https://github.com/samuelbushi/uizze",
+        "repoName": "samuelbushi/uizze",
+        "path": "skills/anti-ui-slop/SKILL.md",
+        "branch": "main"
+      },
+      "featured": false,
+      "tags": [
+        "ui-design",
+        "frontend",
+        "design-systems",
+        "code-quality",
+        "anti-slop"
+      ]
+    },
+    {
       "id": "prd",
       "name": "prd",
       "description": "Generate Product Requirements Documents from feature descriptions. Creates structured PRDs with user stories, acceptance criteria, and technical requirements.",


### PR DESCRIPTION
## Skill Information

**Skill Name:** STOP UI SLOP

**Skill ID:** `anti-ui-slop`

**Category:** `frontend-ui`

**Repository URL:** https://github.com/samuelbushi/uizze

## License

**License:** MIT

- [x] My skill includes a `LICENSE` file in its folder
- [x] The license permits redistribution and derivative works

## Description

Adds UIZZE's free anti-UI-slop workflow for React, Next.js, web, and iOS interface work. It turns real interface evidence into a product-specific design contract, requires the states and responsive decisions the flow needs, and enforces a hard finish gate before shipping.

The free workflow works without an account, token, MCP connection, executable, or dependency. Its public catalogue is at https://uizze.com.

## Triggers

- `stop UI slop`
- `review this UI`
- `make this interface product-specific`
- `finish gate`
- `generic dashboard`

## Checklist

- [x] My skill is hosted in a **public GitHub repository**
- [x] The skill file is named `SKILL.md`
- [x] The skill includes a **LICENSE file** with a redistributable open-source license
- [x] I added my skill to `skills/registry.json`
- [x] All required fields are filled in
- [x] I tested the skill in a project
- [x] The skill follows the contribution guidelines

## Example Usage

```text
Review this checkout screen for UI slop. Write the design contract, verify every required state and breakpoint, then fail the finish gate until the blocking issues are fixed.
```

## Validation

- validated the new registry entry against `skills/schema.json` with AJV Draft 2020
- verified the skill ID is unique and its category exists
- verified the public `SKILL.md` and skill-local MIT license are live on `main`
- checked the source path and plain UIZZE URL
- `git diff --check`
